### PR TITLE
Support for specifying poll directory in SFTP source 

### DIFF
--- a/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
+++ b/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
@@ -298,11 +298,16 @@ public class SFTPSource extends KeedioSource<ChannelSftp.LsEntry> {
     public String getDirectoryserver() throws IOException {
         String printWorkingDirectory = "";
         try {
-            printWorkingDirectory = sftpClient.pwd();
+            printWorkingDirectory = sftpClient.getHome();
         } catch (SftpException e) {
             LOGGER.error("Error getting printworkingdirectory for server -sftpsource",e);
             throw new IOException(e.getMessage());
         }
+        
+        if (getWorkingDirectory != null){
+            return printWorkingDirectory + "/" + getWorkingDirectory();
+        }
+        
         return printWorkingDirectory;
     }
 

--- a/src/main/resources/example-configs/flume-ng-ftp-source-SFTP.conf
+++ b/src/main/resources/example-configs/flume-ng-ftp-source-SFTP.conf
@@ -25,6 +25,9 @@ agent.sources.sftp1.user = filemon
 
 agent.sources.sftp1.password = secret
 
+# Optional polling directory specification assuming a path relative to sftp1.user home directory
+agent.sources.sftp1.working.directory=/path/to/folder
+
 agent.sources.sftp1.folder = /var/log/flume-ftp
 agent.sources.sftp1.file.name = sftp1-status-file.ser
 


### PR DESCRIPTION
Adding minor changes for pulling data from a user specified directory relative to the sftp server's home directory in the case agent.sources.sftp1.working.directory property is set. Otherwise the poll directory defaults to the server's home directory.
