### PR TITLE
Multiple code improvements - squid:S1854, squid:S1488

### DIFF
--- a/src/main/java/org/keedio/flume/source/ftp/client/sources/FTPSSource.java
+++ b/src/main/java/org/keedio/flume/source/ftp/client/sources/FTPSSource.java
@@ -115,12 +115,8 @@ public class FTPSSource extends KeedioSource<FTPFile> {
      * @param current directory
      */
     public List<FTPFile> listElements(String dir) throws IOException {
-        List<FTPFile> list = new ArrayList<>();
-
         FTPFile[] subFiles = getFtpsClient().listFiles(dir);
-        list = Arrays.asList(subFiles);
-
-        return list;
+        return Arrays.asList(subFiles);
     }
 
     @Override
@@ -129,16 +125,13 @@ public class FTPSSource extends KeedioSource<FTPFile> {
      * @return InputStream
      */
     public InputStream getInputStream(FTPFile file) throws IOException {
-        InputStream inputStream = null;
-
         if (isFlushLines()) {
             this.setFileType(FTP.ASCII_FILE_TYPE);
         } else {
             this.setFileType(FTP.BINARY_FILE_TYPE);
         }
-        inputStream = getFtpsClient().retrieveFileStream(file.getName());
 
-        return inputStream;
+        return getFtpsClient().retrieveFileStream(file.getName());
     }
 
     @Override
@@ -219,9 +212,7 @@ public class FTPSSource extends KeedioSource<FTPFile> {
      * @return String directory retrieved for server on connect
      */
     public String getDirectoryserver() throws IOException {
-        String printWorkingDirectory = "";
-        printWorkingDirectory = getFtpsClient().printWorkingDirectory();
-        return printWorkingDirectory;
+        return getFtpsClient().printWorkingDirectory();
     }
 
     /**

--- a/src/main/java/org/keedio/flume/source/ftp/client/sources/FTPSource.java
+++ b/src/main/java/org/keedio/flume/source/ftp/client/sources/FTPSource.java
@@ -98,10 +98,8 @@ public class FTPSource extends KeedioSource<FTPFile> {
      * @param current directory
      */
     public List<FTPFile> listElements(String dir) throws IOException {
-        List<FTPFile> list = new ArrayList<>();
         FTPFile[] subFiles = getFtpClient().listFiles(dir);
-        list = Arrays.asList(subFiles);
-        return list;
+        return Arrays.asList(subFiles);
     }
 
     @Override
@@ -110,16 +108,12 @@ public class FTPSource extends KeedioSource<FTPFile> {
      * @return InputStream
      */
     public InputStream getInputStream(FTPFile file) throws IOException {
-        InputStream inputStream = null;
-
         if (isFlushLines()) {
             this.setFileType(FTP.ASCII_FILE_TYPE);
         } else {
             this.setFileType(FTP.BINARY_FILE_TYPE);
         }
-        inputStream = getFtpClient().retrieveFileStream(file.getName());
-
-        return inputStream;
+        return getFtpClient().retrieveFileStream(file.getName());
     }
 
     @Override
@@ -201,9 +195,7 @@ public class FTPSource extends KeedioSource<FTPFile> {
      */
     @Override
     public String getDirectoryserver() throws IOException {
-        String printWorkingDirectory = "";
-        printWorkingDirectory = getFtpClient().printWorkingDirectory();
-        return printWorkingDirectory;
+        return getFtpClient().printWorkingDirectory();
     }
 
     /**

--- a/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
+++ b/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
@@ -231,7 +231,7 @@ public class SFTPSource extends KeedioSource<ChannelSftp.LsEntry> {
      * @param file to check
      */
     public boolean isFile(ChannelSftp.LsEntry file) {
-        boolean isfile = false;
+        boolean isfile;
         if ((!isDirectory(file)) && (!isLink(file))) {
             isfile = true;
         } else {

--- a/src/main/java/org/keedio/flume/source/ftp/source/Source.java
+++ b/src/main/java/org/keedio/flume/source/ftp/source/Source.java
@@ -162,7 +162,7 @@ public class Source extends AbstractSource implements Configurable, PollableSour
     // @SuppressWarnings("UnnecessaryContinue")
     public <T> void discoverElements(KeedioSource keedioSource, String parentDir, String currentDir, int level) throws IOException {
 
-        long position = 0L;
+        long position;
 
         String dirToList = parentDir;
         if (!("").equals(currentDir)){
@@ -277,7 +277,7 @@ public class Source extends AbstractSource implements Configurable, PollableSour
             try {
                 inputStream.skip(position);
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()))) {
-                    String line = null;
+                    String line;
 
                     while ((line = in.readLine()) != null) {
                         processMessage(line.getBytes());
@@ -295,7 +295,7 @@ public class Source extends AbstractSource implements Configurable, PollableSour
                 inputStream.skip(position);
                 int chunkSize = keedioSource.getChunkSize();
                 byte[] bytesArray = new byte[chunkSize];
-                int bytesRead = -1;
+                int bytesRead;
                 while ((bytesRead = inputStream.read(bytesArray)) != -1) {
                     try (ByteArrayOutputStream baostream = new ByteArrayOutputStream(chunkSize)) {
                         baostream.write(bytesArray, 0, bytesRead);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava
