### PR TITLE
Issue 24 switch working directory on SFTP connect

### DIFF
--- a/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
+++ b/src/main/java/org/keedio/flume/source/ftp/client/sources/SFTPSource.java
@@ -66,11 +66,19 @@ public class SFTPSource extends KeedioSource<ChannelSftp.LsEntry> {
                     sftpClient = (ChannelSftp) channel;
                 }
             }
+
+            if (getWorkingDirectory() != null) {
+                sftpClient.cd(getWorkingDirectory());
+            }
+
         } catch (JSchException e) {
             if (!(sessionSftp.isConnected())) {
                 LOGGER.info("JSchException ", e);
                 this.setConnected(false);
             }
+        } catch (SftpException e) {
+            this.setConnected(false);
+            LOGGER.error("", e);
         }
         return isConnected();
     }


### PR DESCRIPTION
 If working.directory is set, switch to the provided path after the SFTP client connnects.
